### PR TITLE
Add URL for issue tracker

### DIFF
--- a/custom_components/hoymiles_wifi/manifest.json
+++ b/custom_components/hoymiles_wifi/manifest.json
@@ -3,6 +3,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/suaveolent/ha-hoymiles-wifi",
+  "issue_tracker": "https://github.com/suaveolent/ha-hoymiles-wifi/issues",
   "domain": "hoymiles_wifi",
   "iot_class": "local_polling",
   "name": "Hoymiles HMS-XXXXW-2T",


### PR DESCRIPTION
We already have a link to the documentation on the integration page. This PR will add a link to known issues, means people can report issues easier.