### PR TITLE
Fix Typo in DE translation 

### DIFF
--- a/custom_components/hoymiles_wifi/translations/de.json
+++ b/custom_components/hoymiles_wifi/translations/de.json
@@ -58,7 +58,7 @@
         "name": "Port {port_number} DC-Leistung"
       },
       "port_dc_total_energy": {
-        "name": "Port {port_numbe} DC-Gesamtenergie"
+        "name": "Port {port_number} DC-Gesamtenergie"
       },
       "port_dc_daily_energy": {
         "name": "Port {port_number} DC-Tagesenergie"


### PR DESCRIPTION
SSIA

resulted in 
```
Logger: homeassistant.helpers.translation
Source: helpers/translation.py:288
First occurred: 16:04:57 (1 occurrences)
Last logged: 16:04:57

Validation of translation placeholders for localized (de) string component.hoymiles_wifi.entity.sensor.port_dc_total_energy.name failed
```