### PR TITLE
Minor improvements for german translations

### DIFF
--- a/custom_components/hoymiles_wifi/translations/de.json
+++ b/custom_components/hoymiles_wifi/translations/de.json
@@ -49,10 +49,10 @@
         "name": "Temperatur"
       },
       "port_dc_voltage": {
-        "name": "Port {port_number} Gleichspannung"
+        "name": "Port {port_number} DC-Spannung"
       },
       "port_dc_current": {
-        "name": "Port {port_number} Gleichstrom"
+        "name": "Port {port_number} DC-Strom"
       },
       "port_dc_power": {
         "name": "Port {port_number} DC-Leistung"
@@ -97,19 +97,19 @@
         "name": "Spannung Phase A"
       },
       "voltage_phase_B": {
-        "name": "Voltage Phase B"
+        "name": "Spannung Phase B"
       },
       "voltage_phase_C": {
-        "name": "Voltage Phase C"
+        "name": "Spannung Phase C"
       },
       "voltage_line_AB": {
-        "name": "Voltage Phase AB"
+        "name": "Spannung Phase AB"
       },
       "voltage_line_BC": {
-        "name": "Voltage Phase BC"
+        "name": "Spannung Phase BC"
       },
       "voltage_line_CA": {
-        "name": "Voltage Phase CA"
+        "name": "Spannung Phase CA"
       }
     },
     "button": {


### PR DESCRIPTION
- It's not common in german language to say `Gleichspannung or Gleichstrom` in the context of solar power, although it is correct per definition. The term `DC` is more common in this case.
- Fixed the voltage texts for all phases