### PR TITLE
Fix deprecated async_forward_entry_setups call

### DIFF
--- a/custom_components/hoymiles_wifi/coordinator.py
+++ b/custom_components/hoymiles_wifi/coordinator.py
@@ -55,11 +55,7 @@ class HoymilesRealDataUpdateCoordinator(HoymilesDataUpdateCoordinator):
         response = await self._dtu.async_get_real_data_new()
 
         if not self._entities_added:
-            self._hass.async_create_task(
-                self._hass.config_entries.async_forward_entry_setups(
-                    self._entry, PLATFORMS
-                )
-            )
+            await self._hass.config_entries.async_forward_entry_setups(self._entry, PLATFORMS)
             self._entities_added = True
 
         if not response:


### PR DESCRIPTION
Just received a warning in HA which should be easily fixable according to https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/

```
Logger: homeassistant.helpers.frame
Quelle: helpers/frame.py:234
Erstmals aufgetreten: 08:42:43 (1 Vorkommnisse)
Zuletzt protokolliert: 08:42:43

Detected code that calls async_forward_entry_setups for integration hoymiles_wifi with title: HMS-800W-2T and entry_id: fb21083b81e18f5679f63f4d1b461c2d, during setup without awaiting async_forward_entry_setups, which can cause the setup lock to be released before the setup is done. This will stop working in Home Assistant 2025.1, please report this issue
```

Not yet tested with my HMS-800W-2T, but I will do so the next days in my test environment.