### PR TITLE
Bump hoymiles-wifi requirement to latest version

### DIFF
--- a/custom_components/hoymiles_wifi/manifest.json
+++ b/custom_components/hoymiles_wifi/manifest.json
@@ -7,6 +7,6 @@
   "domain": "hoymiles_wifi",
   "iot_class": "local_polling",
   "name": "Hoymiles",
-  "requirements": ["hoymiles-wifi==0.5.0"],
+  "requirements": ["hoymiles-wifi==0.5.2"],
   "version": "0.4.0"
 }


### PR DESCRIPTION
Hi,

I just rebuilt my air-gapped HA Docker container and saw that pip installed the version 0.5.2

Greetz
pottah