### PR TITLE
Fix TGS current phase sensor keys for three-phase inverter

### DIFF
--- a/custom_components/hoymiles_wifi/sensor.py
+++ b/custom_components/hoymiles_wifi/sensor.py
@@ -280,7 +280,7 @@ HOYMILES_SENSORS = [
         conversion_factor=0.01,
     ),
     HoymilesSensorEntityDescription(
-        key="tgs_data[<inverter_count>.current_phase_A",
+        key="tgs_data[<inverter_count>].current_phase_A",
         translation_key="current_phase_A",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
@@ -288,7 +288,7 @@ HOYMILES_SENSORS = [
         conversion_factor=0.01,
     ),
     HoymilesSensorEntityDescription(
-        key="tgs_data[<inverter_count>.current_phase_B",
+        key="tgs_data[<inverter_count>].current_phase_B",
         translation_key="current_phase_B",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
@@ -296,7 +296,7 @@ HOYMILES_SENSORS = [
         conversion_factor=0.01,
     ),
     HoymilesSensorEntityDescription(
-        key="tgs_data[<inverter_count>.current_phase_C",
+        key="tgs_data[<inverter_count>].current_phase_C",
         translation_key="current_phase_C",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,


### PR DESCRIPTION
**Summary**

Fixes malformed TGS current phase sensor keys for Hoymiles devices.

The `current_phase_A`, `current_phase_B`, and `current_phase_C` sensor definitions were missing the closing `]` in their `tgs_data[<inverter_count>]` path segment, preventing those values from resolving correctly.

**Changes**

- Corrected:
  - `tgs_data[<inverter_count>.current_phase_A`
  - `tgs_data[<inverter_count>.current_phase_B`
  - `tgs_data[<inverter_count>.current_phase_C`

- To:
  - `tgs_data[<inverter_count>].current_phase_A`
  - `tgs_data[<inverter_count>].current_phase_B`
  - `tgs_data[<inverter_count>].current_phase_C`

Fixes #197 